### PR TITLE
ensure migration index default to zero &  added seeding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules
+/sql
+.env

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ DATABASE_URL=postgresql://localhost:${PORT}/${DATABASE_NAME}
 postgres-migration
 ```
 
+You can do a few things like:
+
+* checking the current migration index `postgres-migration index`
+* set the current migration index using `postgres-migration seed 7`
+* run some sql using using `postgres-migration execute "select * from your_table" `
+
 or add this in your `package.json` file.
 
 ```json

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bin": {
     "postgres-migration": "./cli.js"
   },
-  "author": "Thabang Gideon Magaola",
+  "author": "Thabang Gideon Magaola &  André Vermeulen",
   "license": "ISC",
   "dependencies": {
     "dotenv": "^8.2.0",


### PR DESCRIPTION
@Gideon877 Please merge these changes.

I fixed the migrations to ensure that the migration levels are entered into the database correctly. And then migrations should not be run repeatedly.

I also add the ability to seed the migration level using `postgres-migration seed <level>`
